### PR TITLE
fix relative paths with --user-directory-urls

### DIFF
--- a/mkdocs_drawio/plugin.py
+++ b/mkdocs_drawio/plugin.py
@@ -53,7 +53,7 @@ class DrawioPlugin(BasePlugin):
         soup.body.append(lib)
 
         # substitute images with embedded drawio diagram
-        path = Path(page.file.abs_src_path).parent
+        path = Path(page.file.abs_dest_path).parent
 
         for diagram in diagrams:
             diagram.replace_with(
@@ -66,7 +66,7 @@ class DrawioPlugin(BasePlugin):
         return str(soup)
 
     def substitute_image(self, path: Path, src: str, alt: str):
-        diagram_xml = etree.parse(path.joinpath(src))
+        diagram_xml = etree.parse(path.joinpath(src).resolve())
         diagram = self.parse_diagram(diagram_xml, alt)
         escaped_xml = self.escape_diagram(diagram)
 


### PR DESCRIPTION
Use the destination instead of the src path to derive the hmtl parsing. Normalize the path via Path.resolve() to account for non-existing partial paths (c.f. example 4).

Fixes #1 

on-behalf-of: @PHOENIXCONTACT github@phoenixcontact.com