### PR TITLE
fix: special character substitution

### DIFF
--- a/mkdocs_drawio/plugin.py
+++ b/mkdocs_drawio/plugin.py
@@ -104,10 +104,10 @@ class DrawioPlugin(BasePlugin):
 
     @staticmethod
     def escape_diagram(str_xml: str):
-        str_xml = str_xml.replace(r"&", r"&amp;")
-        str_xml = str_xml.replace(r"<", r"&lt;")
-        str_xml = str_xml.replace(r">", r"&gt;")
-        str_xml = str_xml.replace(r'"', r"\&quot;")
-        str_xml = str_xml.replace(r"'", r"&apos;")
-        str_xml = str_xml.replace(r"\n", r"")
+        str_xml = str_xml.replace("&", r"&amp;")
+        str_xml = str_xml.replace("<", r"&lt;")
+        str_xml = str_xml.replace(">", r"&gt;")
+        str_xml = str_xml.replace('"', r"\&quot;")
+        str_xml = str_xml.replace("'", r"&apos;")
+        str_xml = str_xml.replace("\n", r"")
         return str_xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio"
-version = "1.6.3"
+version = "1.6.4"
 description = "MkDocs plugin for embedding Drawio files"
 authors = [
     "Sergey Lukin <onixpro@gmail.com>",


### PR DESCRIPTION
# Description
The previous PR #8 broke the replacement. It causes the string replace to look for raw strings to be replaced. Instead for the search pattern a "full" string is necessary and only then it needs be replaced by a raw string. This way the sequence handling problem caused by changes in python 3.12 are properly dealt with: https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes

Fixes #9