### PR TITLE
Fix: include assets for darkmode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ keywords = [
     "mkdocs", "plugin", "markdown", "drawio"
 ]
 packages = [
-    { include = "mkdocs_drawio/plugin.py" },
+    { include = "mkdocs_drawio" },
+]
+include = [
+    "mkdocs_drawio/css/*.css",
+    "mkdocs_drawio/js/*.js",
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio"
-version = "1.11.1"
+version = "1.11.2"
 description = "MkDocs plugin for embedding Drawio files"
 authors = [
     "Jan Larwig <jan@larwig.com>",


### PR DESCRIPTION
Fix #34 

Changed `pyproject.toml`:

```
packages = [
    { include = "mkdocs_drawio" },
]
include = [
    "mkdocs_drawio/css/*.css",
    "mkdocs_drawio/js/*.js",
]
```