### PR TITLE
fix(dep): lxml version to support proper path parsing 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio"
-version = "1.12.0"
+version = "1.12.1"
 description = "MkDocs plugin for embedding Drawio files"
 authors = [
     "Jan Larwig <jan@larwig.com>",
@@ -26,7 +26,7 @@ python = ">=3.8.0,<4.0"
 requests = ">=2.0"
 Jinja2 = ">=3.0"
 beautifulsoup4 = ">=4.0"
-lxml = ">=4.0"
+lxml = ">=4.8"
 mkdocs = ">=1.4"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Bump lxml dependency to >=4.8.0 for the relied-upon support of lxml::etree::parse accepting a path-like object.
In mkdocs-drawio source code, in `plugin.py` line 107, lxml::etree::parse function is called with a path-like object (specifically I had it be called with PosixPath).
`parse`'s support of accepting such an object and not just a string was only added in lxml version 4.8.0 (see line 581 here https://github.com/lxml/lxml/blob/master/CHANGES.txt).
Therefore, my PR bumps the dependency, as well of updating `pyproject.toml` towards the release of version 1.12.1, as instructed in the README.
Thank you!