### PR TITLE
fix: Python >3.12 issue with reused quotes in f-strings pre PEP 701

### DIFF
--- a/mkdocs_drawio/plugin.py
+++ b/mkdocs_drawio/plugin.py
@@ -211,7 +211,7 @@ class DrawioPlugin(BasePlugin[DrawioConfig]):
                     )
                 except Exception as e:
                     LOGGER.error(
-                        f"Error: Could not parse diagram file '{diagram["src"]}' on path '{path}': {e}"
+                        f"Error: Could not parse diagram file '{diagram['src']}' on path '{path}': {e}"
                     )
                     diagram_config["xml"] = ""
                     mxgraph = SUB_TEMPLATE.substitute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mkdocs-drawio"
-version = "1.16.0"
+version = "1.16.1"
 description = "MkDocs plugin for embedding Drawio files"
 authors = [
     "Jan Larwig <jan@larwig.com>",


### PR DESCRIPTION
The error message when throwing an exception used a combo of double and single quotes, causing f-string to fail. This was fixed in Python >=3.12, but this fix makes it safe for Python <3.12.

We learn something new every day! =)